### PR TITLE
Renamed interface KeyStore to KeySource

### DIFF
--- a/lib-dempsyapi/src/main/java/com/nokia/dempsy/KeySource.java
+++ b/lib-dempsyapi/src/main/java/com/nokia/dempsy/KeySource.java
@@ -17,11 +17,11 @@
 package com.nokia.dempsy;
 
 /**
- * An {@link KeyStore} is used to provide entire key space to the container
+ * An {@link KeySource} is used to provide entire key space to the container
  * so that it can pre-instantiate the MP's that would reside on the node;
  *
  */
-public interface KeyStore<T>
+public interface KeySource<T>
 {
    /**
     * This will be called by Dempsy to retrieve all possible keys that the 

--- a/lib-dempsyapi/src/main/java/com/nokia/dempsy/config/ClusterDefinition.java
+++ b/lib-dempsyapi/src/main/java/com/nokia/dempsy/config/ClusterDefinition.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 
 import com.nokia.dempsy.Adaptor;
 import com.nokia.dempsy.DempsyException;
-import com.nokia.dempsy.KeyStore;
+import com.nokia.dempsy.KeySource;
 import com.nokia.dempsy.annotations.MessageHandler;
 import com.nokia.dempsy.annotations.MessageProcessor;
 import com.nokia.dempsy.annotations.Start;
@@ -48,7 +48,7 @@ public class ClusterDefinition
    private Object statsCollectorFactory = null;
    private OutputSchedule outputScheduler = null;
    private boolean adaptorIsDaemon = false;
-   private KeyStore<?> keyStore = null;
+   private KeySource<?> keySource = null;
    
    private ApplicationDefinition parent;
    
@@ -154,8 +154,8 @@ public class ClusterDefinition
    public ClusterDefinition setAdaptor(Adaptor adaptor) { this.adaptor = adaptor; return this; }
    public boolean isAdaptorDaemon() { return adaptorIsDaemon; }
    public ClusterDefinition setAdaptorDaemon(boolean isAdaptorDaemon) { this.adaptorIsDaemon = isAdaptorDaemon; return this; }
-   public KeyStore<?> getKeyStore(){ return keyStore; }
-   public ClusterDefinition setKeyStore(KeyStore<?> keyStore){ this.keyStore = keyStore; return this; }
+   public KeySource<?> getKeySource(){ return keySource; }
+   public ClusterDefinition setKeySource(KeySource<?> keySource){ this.keySource = keySource; return this; }
    
    @Override
    public String toString()
@@ -223,7 +223,7 @@ public class ClusterDefinition
             throw new DempsyException("Multiple methods on the message processor of type\""
                   + SafeString.valueOf(messageProcessorPrototype) + "\" is identified as a Start method. Please annotate at most one method using @Start.");
       }
-      if(adaptor != null && keyStore != null)
+      if(adaptor != null && keySource != null)
       {
          throw new DempsyException("A dempsy cluster can not pre-instantation an adaptor.");
       }

--- a/lib-dempsyapi/src/test/java/com/nokia/dempsy/config/TestConfig.java
+++ b/lib-dempsyapi/src/test/java/com/nokia/dempsy/config/TestConfig.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import com.nokia.dempsy.Adaptor;
 import com.nokia.dempsy.DempsyException;
 import com.nokia.dempsy.Dispatcher;
-import com.nokia.dempsy.KeyStore;
+import com.nokia.dempsy.KeySource;
 import com.nokia.dempsy.annotations.MessageHandler;
 import com.nokia.dempsy.annotations.MessageKey;
 import com.nokia.dempsy.annotations.MessageProcessor;
@@ -261,7 +261,7 @@ public class TestConfig
       ApplicationDefinition app = new ApplicationDefinition("test");
       ClusterDefinition cd = new ClusterDefinition("test-slot");
       cd.setMessageProcessorPrototype(new GoodTestMp());
-      cd.setKeyStore(new KeyStore<Object>()
+      cd.setKeySource(new KeySource<Object>()
       {
          @Override
          public Iterable<Object> getAllPossibleKeys(){ return null; }
@@ -276,7 +276,7 @@ public class TestConfig
       ApplicationDefinition app = new ApplicationDefinition("test");
       ClusterDefinition cd = new ClusterDefinition("test-slot");
       cd.setMessageProcessorPrototype(new GoodTestMp())
-      .setKeyStore(new KeyStore<Object>()
+      .setKeySource(new KeySource<Object>()
       {
          @Override
          public Iterable<Object> getAllPossibleKeys()
@@ -304,7 +304,7 @@ public class TestConfig
          @Override
          public void setDispatcher(Dispatcher dispatcher){ }
       })
-      .setKeyStore(new KeyStore<Object>()
+      .setKeySource(new KeySource<Object>()
       {
          @Override
          public Iterable<Object> getAllPossibleKeys()

--- a/lib-dempsycore/src/main/java/com/nokia/dempsy/router/RoutingStrategy.java
+++ b/lib-dempsycore/src/main/java/com/nokia/dempsy/router/RoutingStrategy.java
@@ -89,7 +89,7 @@ public interface RoutingStrategy
       public void resetCluster(MpCluster<ClusterInformation, SlotInformation> cluster,
             List<Class<?>> messageTypes, Destination thisDestination) throws MpClusterException;
       
-      public boolean doesMessageKeyBelongToCluster(Object messageKey);
+      public boolean doesMessageKeyBelongToNode(Object messageKey);
    }
    
    public Inbound createInbound();

--- a/lib-dempsyimpl/src/main/java/com/nokia/dempsy/Dempsy.java
+++ b/lib-dempsyimpl/src/main/java/com/nokia/dempsy/Dempsy.java
@@ -160,8 +160,8 @@ public class Dempsy
                   if (adaptor != null)
                      adaptor.setDispatcher(router);
                   
-                  final KeyStore<?> keyStore = clusterDefinition.getKeyStore();
-                  if(keyStore != null)
+                  final KeySource<?> keySource = clusterDefinition.getKeySource();
+                  if(keySource != null)
                   {
                      Thread t = new Thread(new Runnable()
                      {
@@ -170,12 +170,12 @@ public class Dempsy
                         {
                            try{
                               statsCollector.preInstantiationStarted();
-                              Iterable<?> iterable = keyStore.getAllPossibleKeys();
+                              Iterable<?> iterable = keySource.getAllPossibleKeys();
                               for(Object key: iterable)
                               {
                                  try
                                  {
-                                    if(strategyInbound.doesMessageKeyBelongToCluster(key))
+                                    if(strategyInbound.doesMessageKeyBelongToNode(key))
                                     {
                                           container.getInstanceForKey(key);
                                     }
@@ -190,7 +190,7 @@ public class Dempsy
                            catch(Throwable e)
                            {
                               logger.error("Exception occured while processing keys during pre-instantiation using KeyStore method"+
-                                    keyStore.getClass().getSimpleName()+":getAllPossibleKeys()", e);
+                                    keySource.getClass().getSimpleName()+":getAllPossibleKeys()", e);
                            }
                            finally
                            {

--- a/lib-dempsyimpl/src/main/java/com/nokia/dempsy/router/DefaultRoutingStrategy.java
+++ b/lib-dempsyimpl/src/main/java/com/nokia/dempsy/router/DefaultRoutingStrategy.java
@@ -144,7 +144,7 @@ public class DefaultRoutingStrategy implements RoutingStrategy
       }
       
       @Override
-      public boolean doesMessageKeyBelongToCluster(Object messageKey)
+      public boolean doesMessageKeyBelongToNode(Object messageKey)
       {
          return destinationsAcquired.contains(messageKey.hashCode()%defaultTotalSlots);
       }

--- a/lib-dempsyimpl/src/test/java/com/nokia/dempsy/TestDempsy.java
+++ b/lib-dempsyimpl/src/test/java/com/nokia/dempsy/TestDempsy.java
@@ -187,7 +187,7 @@ public class TestDempsy
       }
    }
    
-   public static class KeyStoreImpl implements KeyStore<String>
+   public static class KeySourceImpl implements KeySource<String>
    {
       @Override
       public Iterable<String> getAllPossibleKeys()

--- a/lib-dempsyimpl/src/test/resources/testDempsy/SinglestageWithKeyStoreApplicationActx.xml
+++ b/lib-dempsyimpl/src/test/resources/testDempsy/SinglestageWithKeyStoreApplicationActx.xml
@@ -20,8 +20,8 @@
                <property name="messageProcessorPrototype">
                   <bean class="com.nokia.dempsy.TestDempsy$TestMp" />
                </property>
-               <property name="keyStore">
-                  <bean class="com.nokia.dempsy.TestDempsy.KeyStoreImpl"/>
+               <property name="keySource">
+                  <bean class="com.nokia.dempsy.TestDempsy.KeySourceImpl"/>
                </property>
             </bean>
          </list>


### PR DESCRIPTION
Renamed method RoutingStrategy.Inbound.doesMessageKeyBelongToCluster to RoutingStrategy.Inbound.doesMessageKeyBelongToNode

closes #26
