### PR TITLE
The Passthrough message transport message shedding optional

### DIFF
--- a/lib-dempsyimpl/src/main/java/com/nokia/dempsy/messagetransport/passthrough/PassthroughTransport.java
+++ b/lib-dempsyimpl/src/main/java/com/nokia/dempsy/messagetransport/passthrough/PassthroughTransport.java
@@ -19,6 +19,7 @@ package com.nokia.dempsy.messagetransport.passthrough;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.nokia.dempsy.Adaptor;
 import com.nokia.dempsy.internal.util.SafeString;
 import com.nokia.dempsy.messagetransport.Destination;
 import com.nokia.dempsy.messagetransport.Listener;
@@ -29,15 +30,23 @@ import com.nokia.dempsy.messagetransport.Sender;
 import com.nokia.dempsy.messagetransport.SenderFactory;
 import com.nokia.dempsy.messagetransport.Transport;
 
+/**
+ * This transport is basically an inVM transport where the call-stack becomes 
+ * the transport mechanism. It's primarily for testing when completely deterministic 
+ * behavior is required.
+ * 
+ * When the 'send' call simply directly calls the {@link Listener} on the receive
+ * side. As a result the thread will basically block in the 'send' until that message 
+ * is handled, by the {@link Listener} in the same thread the 'send' was called in.
+ * 
+ * When an inVM Dempsy application is using this transport the effect is that the
+ * initial {@link Adaptor}'s call to 'send' will not return until that message is
+ * processed and any resulting messages are passed on to the next Mp in the processing 
+ * chain and those are processed.
+ */
 public class PassthroughTransport implements Transport
 {
-
-   private static class PassthroughDestination implements Destination
-   {
-      Sender sender;
-      
-      PassthroughDestination(Sender sender) { this.sender = sender; }
-   }
+   private boolean failFast = true;
    
    @Override
    public SenderFactory createOutbound() throws MessageTransportException
@@ -74,7 +83,7 @@ public class PassthroughTransport implements Transport
             public void send(byte[] messageBytes) throws MessageTransportException
             {
                for (Listener listener : listeners)
-                  listener.onMessage(messageBytes, true);
+                  listener.onMessage(messageBytes, failFast);
             }
          };
          
@@ -103,5 +112,34 @@ public class PassthroughTransport implements Transport
    {
       throw new UnsupportedOperationException();
    }
-
+   
+   /**
+    * <p>Failfast is set to true by default. This means that if the Mp is busy 
+    * that is the target for the sent message it busy, it will simply dicard
+    * the message being sent.</p>
+    * 
+    * <p>Setting 'failFast' to 'false' allows multi-threaded {@link Adaptor}'s
+    * to use the passthough in a more deterministic fashion than would otherwise
+    * be allowed.</p>
+    */
+   public void setFailFast(boolean failFast) { this.failFast = failFast; }
+   
+   /**
+    * <p>Failfast is set to true by default. This means that if the Mp is busy 
+    * that is the target for the sent message it busy, it will simply dicard
+    * the message being sent.</p>
+    * 
+    * <p>Setting 'failFast' to 'false' allows multi-threaded {@link Adaptor}'s
+    * to use the passthough in a more deterministic fashion than would otherwise
+    * be allowed.</p>
+    */
+   public boolean getFailFast() { return failFast; }
+   
+   private static class PassthroughDestination implements Destination
+   {
+      Sender sender;
+      
+      PassthroughDestination(Sender sender) { this.sender = sender; }
+   }
+   
 }

--- a/lib-dempsyimpl/src/test/java/com/nokia/dempsy/TestDempsy.java
+++ b/lib-dempsyimpl/src/test/java/com/nokia/dempsy/TestDempsy.java
@@ -64,14 +64,12 @@ public class TestDempsy
    String[] dempsyConfigs = new String[] { "testDempsy/Dempsy.xml" };
    
    String[] clusterManagers = new String[]{ "testDempsy/ClusterManager-ZookeeperActx.xml", "testDempsy/ClusterManager-LocalVmActx.xml" };
-   String[] transports = new String[]
-         { "testDempsy/Transport-PassthroughActx.xml", 
-         "testDempsy/Transport-BlockingQueueActx.xml", 
-         null // this means use the alternatingTransports
-         };
+   String[][] transports = new String[][] {
+         { "testDempsy/Transport-PassthroughActx.xml", "testDempsy/Transport-PassthroughBlockingActx.xml" }, 
+         { "testDempsy/Transport-BlockingQueueActx.xml" }, 
+         { "testDempsy/Transport-TcpActx.xml", "testDempsy/Transport-TcpWithOverflowActx.xml" }
+   };
    
-   String[] alternatingTransports = { "testDempsy/Transport-TcpActx.xml", "testDempsy/Transport-TcpWithOverflowActx.xml" };
-
    // bad combinations.
    List<ClusterId> badCombos = Arrays.asList(new ClusterId[] {
          // this is a hack ... use a ClusterId as a String tuple for comparison
@@ -230,11 +228,10 @@ public class TestDempsy
       int runCount = 0;
       for (String clusterManager : clusterManagers)
       {
-         for (String transport : transports)
+         for (String[] alternatingTransports : transports)
          {
             // select one of the alternatingTransports
-            if (transport == null)
-               transport = alternatingTransports[runCount % alternatingTransports.length];
+            String transport = alternatingTransports[runCount % alternatingTransports.length];
 
             // alternate the dempsy configs
             String dempsyConfig = dempsyConfigs[runCount % dempsyConfigs.length];

--- a/lib-dempsyimpl/src/test/resources/testDempsy/Transport-PassthroughBlockingActx.xml
+++ b/lib-dempsyimpl/src/test/resources/testDempsy/Transport-PassthroughBlockingActx.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:util="http://www.springframework.org/schema/util" xmlns:context="http://www.springframework.org/schema/context"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+	<bean name="transport"
+		class="com.nokia.dempsy.messagetransport.passthrough.PassthroughTransport" >
+		<property name="failFast" value="true" />
+	</bean>
+</beans>


### PR DESCRIPTION
The Passthrough message transport can now be configured to use the 'failFast' option of the MpContainer. Closes Issue#49.
